### PR TITLE
Use per-datacenter aggregations

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ async function pollFromFastly(service) {
     } else {
       timestamp = valuableData.Timestamp
       valuableData.Data.map((data) => {
-        batchAndSend(data.aggregated, { id: service, name: serviceDetail.name });
+        batchAndSend(data.datacenter, { id: service, name: serviceDetail.name });
       })
     }
 
@@ -59,16 +59,21 @@ async function pollFromFastly(service) {
 }
 
 async function batchAndSend(aggregate, service) {
-  let message = {
-    "eventType": EVENT_TYPE,
-    "service_id": service.id,
-    "service_name": service.name,
-    ...aggregate,
+  const events = []
+  for (const [datacenter, metrics] of Object.entries(aggregate)) {
+    events.push({
+      "eventType": EVENT_TYPE,
+      "service_id": service.id,
+      "service_name": service.name,
+      datacenter,
+      ...metrics,
+    });
   }
-  await sendToInsights(message)
+
+  await sendToInsights(events)
 }
 
-async function sendToInsights(logMessages) {
+async function sendToInsights(events) {
   let insights_url = `https://${INSIGHTS_HOST}/v1/accounts/${ACCOUNT_ID}/events`;
   try {
     fetch(insights_url, {
@@ -77,7 +82,7 @@ async function sendToInsights(logMessages) {
         'Content-Type': 'application/json',
         "X-Insert-Key": INSERT_KEY
       },
-      body: JSON.stringify(logMessages)
+      body: JSON.stringify(events)
     });
   } catch (error) {
     console.log('error posting to insights', error);

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 // Copyright 2018 New Relic, Inc.  Licensed under the Apache License, version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, either express or implied. 
 //Copyright 2018 New Relic Inc. All rights reserved.
 
+import { gzipSync } from 'node:zlib';
 import fetch from 'node-fetch';
 import { ApiClient, RealtimeApi, ServiceApi } from "fastly";
 
@@ -76,13 +77,15 @@ async function batchAndSend(aggregate, service) {
 async function sendToInsights(events) {
   let insights_url = `https://${INSIGHTS_HOST}/v1/accounts/${ACCOUNT_ID}/events`;
   try {
+    const body = gzipSync(JSON.stringify(events));
     fetch(insights_url, {
       method: "POST",
       headers: {
         'Content-Type': 'application/json',
+        'Content-Encoding': 'gzip',
         "X-Insert-Key": INSERT_KEY
       },
-      body: JSON.stringify(events)
+      body
     });
   } catch (error) {
     console.log('error posting to insights', error);

--- a/index.js
+++ b/index.js
@@ -71,7 +71,9 @@ async function batchAndSend(aggregate, service) {
     });
   }
 
-  await sendToInsights(events)
+  if (events.length > 0) {
+    await sendToInsights(events);
+  }
 }
 
 async function sendToInsights(events) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "fastly-to-insights",
-  "version": "1.1.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.1.0",
+      "name": "fastly-to-insights",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "fastly": "^3.1.0",
+        "fastly": "^10.0.0",
         "node-fetch": "^3.3.0"
       }
     },
@@ -88,14 +89,12 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "node_modules/fastly": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fastly/-/fastly-3.1.0.tgz",
-      "integrity": "sha512-2B8ZZOakM5GAsQAx3f/EbtiiAMDFEnQFKG/5RsakqqvmysPqXa+2IgLZcLkoPDHTuzsehU9B+YRiQiBgpV+KzQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/fastly/-/fastly-10.0.0.tgz",
+      "integrity": "sha512-J3ASO0AKqAcQQAdKCg2zkDf/zCeUD115B1TK9nxFEapwqu3an2ndlCTfOGtOCrc23TzRUpjhSfveYw395Ru9JA==",
+      "license": "MIT",
       "dependencies": {
         "superagent": "^6.1.0"
-      },
-      "engines": {
-        "node": "^16"
       }
     },
     "node_modules/fetch-blob": {
@@ -474,9 +473,9 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "fastly": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fastly/-/fastly-3.1.0.tgz",
-      "integrity": "sha512-2B8ZZOakM5GAsQAx3f/EbtiiAMDFEnQFKG/5RsakqqvmysPqXa+2IgLZcLkoPDHTuzsehU9B+YRiQiBgpV+KzQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/fastly/-/fastly-10.0.0.tgz",
+      "integrity": "sha512-J3ASO0AKqAcQQAdKCg2zkDf/zCeUD115B1TK9nxFEapwqu3an2ndlCTfOGtOCrc23TzRUpjhSfveYw395Ru9JA==",
       "requires": {
         "superagent": "^6.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastly-to-insights",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Import Fastly data to New Relic Insights",
   "main": "index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastly-to-insights",
-  "version": "2.2.0",
+  "version": "2.4.0",
   "description": "Import Fastly data to New Relic Insights",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
The aggregate record model includes data across all data centers while the data center record model contains per-data center metrics -- see [Fastly Real-time Analytics API](https://www.fastly.com/documentation/reference/api/metrics-stats/realtime/). This change trades more events for per-data center visibility and global metrics can be achieved without faceting.

- [x] Batch events using per-datacenter aggregations.
- [x] Enable gzip compression.